### PR TITLE
feat(accessor): exposing `ShardAccessor.data` through exported method

### DIFF
--- a/accessor.go
+++ b/accessor.go
@@ -54,8 +54,8 @@ func (sa *ShardAccessor) Shard() shard.Key {
 	return sa.shard.key
 }
 
-func (sa *ShardAccessor) Reader() io.ReadCloser {
-	return sa.data.(io.ReadCloser)
+func (sa *ShardAccessor) Read(p []byte) (int, error) {
+	return sa.data.Read(p)
 }
 
 func (sa *ShardAccessor) Blockstore() (ReadBlockstore, error) {

--- a/accessor.go
+++ b/accessor.go
@@ -54,6 +54,10 @@ func (sa *ShardAccessor) Shard() shard.Key {
 	return sa.shard.key
 }
 
+func (sa *ShardAccessor) Reader() io.ReadCloser {
+	return sa.data.(io.ReadCloser)
+}
+
 func (sa *ShardAccessor) Blockstore() (ReadBlockstore, error) {
 	var r io.ReaderAt = sa.data
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/filecoin-project/dagstore
+module github.com/celestiaorg/dagstore
 
 go 1.16
 
 require (
+	github.com/filecoin-project/dagstore v0.0.0-00010101000000-000000000000
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.5.0
@@ -10,7 +11,6 @@ require (
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/ipld/go-car/v2 v2.1.1
-	github.com/libp2p/go-libp2p-core v0.9.0 // indirect
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multicodec v0.3.1-0.20210902112759-1539a079fd61
 	github.com/multiformats/go-multihash v0.1.0
@@ -21,3 +21,5 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )
+
+replace github.com/filecoin-project/dagstore => ./


### PR DESCRIPTION
Ref: https://github.com/celestiaorg/celestia-node/issues/1101

@Wondertan Is this what you had in mind? Or should it be a `ReadCloser`, or the `mount.Reader`?

