### PR TITLE
feat(ShardAccessor): feat: enable concurrent ShardAccessor usage with mmap

### DIFF
--- a/accessor.go
+++ b/accessor.go
@@ -2,6 +2,7 @@ package dagstore
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -54,47 +55,44 @@ func (sa *ShardAccessor) Shard() shard.Key {
 	return sa.shard.key
 }
 
-func (sa *ShardAccessor) Read(p []byte) (int, error) {
-	sa.lk.Lock()
-	defer sa.lk.Unlock()
-
-	if sa.mmapr == nil {
-		if f, ok := sa.data.(*os.File); ok {
-			if mmapr, err := mmap.Open(f.Name()); err != nil {
-				log.Warnf("failed to mmap reader of type %T: %s; using reader as-is", sa.data, err)
-			} else {
-				sa.mmapr = mmapr
-			}
-		}
+// Reader returns an io.Reader that can be used to read the data from the shard.
+func (sa *ShardAccessor) Reader() io.Reader {
+	return &readerAtWrapper{
+		readerAt: sa.tryMmap(),
 	}
-
-	if sa.mmapr != nil {
-		return sa.mmapr.ReadAt(p, 0)
-	}
-
-	return sa.data.Read(p)
 }
 
 func (sa *ShardAccessor) Blockstore() (ReadBlockstore, error) {
-	var r io.ReaderAt = sa.data
+	r := sa.tryMmap()
+	bs, err := blockstore.NewReadOnly(r, sa.idx, carv2.ZeroLengthSectionAsEOF(true))
+	return bs, err
+}
 
+// tryMmap attempts to mmap the file if the underlying data is an *os.File. It returns an
+// io.ReaderAt which can be used to read the data. If the operation was successful or the file is
+// already mapped , it will return the mmap.ReaderAt. If the memory mapping fails, it falls back to
+// the original io.ReaderAt implementation from the mount.Reader and logs a warning message.
+// The method is safe for concurrent use.
+func (sa *ShardAccessor) tryMmap() io.ReaderAt {
 	sa.lk.Lock()
+	defer sa.lk.Unlock()
+
 	if sa.mmapr != nil {
-		r = sa.mmapr
-	} else if f, ok := sa.data.(*os.File); ok {
+		return sa.mmapr
+	}
+
+	if f, ok := sa.data.(*os.File); ok {
 		if mmapr, err := mmap.Open(f.Name()); err != nil {
 			log.Warnf("failed to mmap reader of type %T: %s; using reader as-is", sa.data, err)
 		} else {
 			// we don't close the mount.Reader file descriptor because the user
 			// may have called other non-mmap-backed accessors.
-			r = mmapr
 			sa.mmapr = mmapr
+			return mmapr
 		}
 	}
-	sa.lk.Unlock()
 
-	bs, err := blockstore.NewReadOnly(r, sa.idx, carv2.ZeroLengthSectionAsEOF(true))
-	return bs, err
+	return sa.data
 }
 
 // Close terminates this shard accessor, releasing any resources associated
@@ -113,4 +111,29 @@ func (sa *ShardAccessor) Close() error {
 
 	tsk := &task{op: OpShardRelease, shard: sa.shard}
 	return sa.shard.d.queueTask(tsk, sa.shard.d.externalCh)
+}
+
+// readerAtWrapper is a wrapper around an io.ReaderAt that implements io.Reader.
+type readerAtWrapper struct {
+	readerAt   io.ReaderAt
+	readOffset int64
+}
+
+func (w *readerAtWrapper) Read(p []byte) (n int, err error) {
+	if w.readerAt == nil {
+		return 0, errors.New("readerAtWrapper: readerAt is nil")
+	}
+
+	n, err = w.readerAt.ReadAt(p, w.readOffset)
+	w.readOffset += int64(n)
+
+	if err == io.EOF {
+		return n, err
+	}
+
+	if err != nil {
+		return n, errors.New("readerAtWrapper: error reading from the underlying ReaderAt")
+	}
+
+	return n, nil
 }

--- a/accessor.go
+++ b/accessor.go
@@ -126,14 +126,9 @@ func (w *readerAtWrapper) Read(p []byte) (n int, err error) {
 
 	n, err = w.readerAt.ReadAt(p, w.readOffset)
 	w.readOffset += int64(n)
-
-	if err == io.EOF {
-		return n, err
-	}
-
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return n, errors.New("readerAtWrapper: error reading from the underlying ReaderAt")
 	}
 
-	return n, nil
+	return n, err
 }

--- a/accessor.go
+++ b/accessor.go
@@ -2,7 +2,7 @@ package dagstore
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -120,14 +120,10 @@ type readerAtWrapper struct {
 }
 
 func (w *readerAtWrapper) Read(p []byte) (n int, err error) {
-	if w.readerAt == nil {
-		return 0, errors.New("readerAtWrapper: readerAt is nil")
-	}
-
 	n, err = w.readerAt.ReadAt(p, w.readOffset)
 	w.readOffset += int64(n)
 	if err != nil && err != io.EOF {
-		return n, errors.New("readerAtWrapper: error reading from the underlying ReaderAt")
+		return n, fmt.Errorf("readerAtWrapper: error reading from the underlying ReaderAt: %w", err)
 	}
 
 	return n, err

--- a/accessor.go
+++ b/accessor.go
@@ -80,7 +80,6 @@ func (sa *ShardAccessor) Blockstore() (ReadBlockstore, error) {
 
 	sa.lk.Lock()
 	if sa.mmapr != nil {
-		// If mmapr is already set, use it.
 		r = sa.mmapr
 	} else if f, ok := sa.data.(*os.File); ok {
 		if mmapr, err := mmap.Open(f.Name()); err != nil {


### PR DESCRIPTION
Related: https://github.com/celestiaorg/celestia-node/issues/1514. Will open a PR there that adds a test to verify this functionality in the LRU cache, and enables cache usage for GetCAR and GetDAH. This will allow shrexeds and shrexnd servers to only require opening the file once (until removed from cache) 

- Update the Read method to use mmapr when available, falling back to the data reader if not
- Refactor the Blockstore method to reuse the mmapr field if it is already set, preventing unnecessary file opens

This change enables concurrent access to the ShardAccessor without opening the file multiple times, improving performance and resource usage.