### PR TITLE
feat: re-adding mmap and locking readerAtWrapper during reads

### DIFF
--- a/accessor.go
+++ b/accessor.go
@@ -3,15 +3,20 @@ package dagstore
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"sync"
+
 	"github.com/filecoin-project/dagstore/mount"
 	"github.com/filecoin-project/dagstore/shard"
-	"io"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/blockstore"
 	"github.com/ipld/go-car/v2/index"
+
+	"golang.org/x/exp/mmap"
 )
 
 // ReadBlockstore is a read-only view of Blockstores. This will be implemented
@@ -30,6 +35,12 @@ type ShardAccessor struct {
 	data  mount.Reader
 	idx   index.Index
 	shard *Shard
+
+	// mmapr is an optional mmap.ReaderAt. It will be non-nil if the mount
+	// has been mmapped because the mount.Reader was an underlying *os.File,
+	// and an mmap-backed accessor was requested (e.g. Blockstore).
+	lk    sync.Mutex
+	mmapr *mmap.ReaderAt
 }
 
 func NewShardAccessor(data mount.Reader, idx index.Index, s *Shard) (*ShardAccessor, error) {
@@ -47,13 +58,45 @@ func (sa *ShardAccessor) Shard() shard.Key {
 // Reader returns an io.Reader that can be used to read the data from the shard.
 func (sa *ShardAccessor) Reader() io.Reader {
 	return &readerAtWrapper{
-		readerAt: sa.data,
+		readerAt: sa.tryMmap(),
+		accessor: sa,
 	}
 }
 
 func (sa *ShardAccessor) Blockstore() (ReadBlockstore, error) {
-	bs, err := blockstore.NewReadOnly(sa.data, sa.idx, carv2.ZeroLengthSectionAsEOF(true))
+	r := &readerAtWrapper{
+		readerAt: sa.tryMmap(),
+		accessor: sa,
+	}
+	bs, err := blockstore.NewReadOnly(r, sa.idx, carv2.ZeroLengthSectionAsEOF(true))
 	return bs, err
+}
+
+// tryMmap attempts to mmap the file if the underlying data is an *os.File. It returns an
+// io.ReaderAt which can be used to read the data. If the operation was successful or the file is
+// already mapped , it will return the mmap.ReaderAt. If the memory mapping fails, it falls back to
+// the original io.ReaderAt implementation from the mount.Reader and logs a warning message.
+// The method is safe for concurrent use.
+func (sa *ShardAccessor) tryMmap() io.ReaderAt {
+	sa.lk.Lock()
+	defer sa.lk.Unlock()
+
+	if sa.mmapr != nil {
+		return sa.mmapr
+	}
+
+	if f, ok := sa.data.(*os.File); ok {
+		if mmapr, err := mmap.Open(f.Name()); err != nil {
+			log.Warnf("failed to mmap reader of type %T: %s; using reader as-is", sa.data, err)
+		} else {
+			// we don't close the mount.Reader file descriptor because the user
+			// may have called other non-mmap-backed accessors.
+			sa.mmapr = mmapr
+			return mmapr
+		}
+	}
+
+	return sa.data
 }
 
 // Close terminates this shard accessor, releasing any resources associated
@@ -62,6 +105,13 @@ func (sa *ShardAccessor) Close() error {
 	if err := sa.data.Close(); err != nil {
 		log.Warnf("failed to close mount when closing shard accessor: %s", err)
 	}
+	sa.lk.Lock()
+	if sa.mmapr != nil {
+		if err := sa.mmapr.Close(); err != nil {
+			log.Warnf("failed to close mmap when closing shard accessor: %s", err)
+		}
+	}
+	sa.lk.Unlock()
 
 	tsk := &task{op: OpShardRelease, shard: sa.shard}
 	return sa.shard.d.queueTask(tsk, sa.shard.d.externalCh)
@@ -71,9 +121,13 @@ func (sa *ShardAccessor) Close() error {
 type readerAtWrapper struct {
 	readerAt   io.ReaderAt
 	readOffset int64
+	// backreference to the accessor to prevent concurrent ReadAt+Close from mmap
+	accessor *ShardAccessor
 }
 
 func (w *readerAtWrapper) Read(p []byte) (n int, err error) {
+	w.accessor.lk.Lock()
+	defer w.accessor.lk.Unlock()
 	n, err = w.readerAt.ReadAt(p, w.readOffset)
 	w.readOffset += int64(n)
 	if err != nil && err != io.EOF {
@@ -81,4 +135,10 @@ func (w *readerAtWrapper) Read(p []byte) (n int, err error) {
 	}
 
 	return n, err
+}
+
+func (w *readerAtWrapper) ReadAt(p []byte, offset int64) (int, error) {
+	w.accessor.lk.Lock()
+	defer w.accessor.lk.Unlock()
+	return w.readerAt.ReadAt(p, offset)
 }


### PR DESCRIPTION
By adding a backreference to the shard accessor to the readerAtWrapper, we can lock the lock from the accessor on reads. We also extend readerAt wrapper to implement ReadAt with a lock first so we can pass it to the blockstore constructor. This is the same lock that is locked on eviction (during mmap.close), so now no closes happen in the middle of a read.

This is something that is overlooked upstream, so boost would probably also segfault. I will open an issue tomorrow on their repo